### PR TITLE
[#31]feat: 시각화 페이지에 접속시 교육자에게 정보 전달

### DIFF
--- a/src/main/java/soma/edupilms/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupilms/classroom/account/ClassroomAccountController.java
@@ -49,6 +49,19 @@ public class ClassroomAccountController {
             ));
     }
 
+    @GetMapping("/v1/classroom/account/progress")
+    public ResponseEntity<SuccessResponse> getClassroomAccountWithoutDefaultAction(@RequestParam Long classroomId) {
+        GuestsResponse classroomAccountResponses =
+            classroomAccountService.getClassroomAccountsWithoutDefaultAction(classroomId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(SuccessResponse.withDetailAndResult(
+                "success retrieved classroom account without default action by classroomId",
+                classroomAccountResponses
+            ));
+    }
+
     @DeleteMapping("/v1/classroom/account")
     public ResponseEntity<SuccessResponse> deleteClassroomAccount(@RequestParam Long classroomAccountId) {
         classroomAccountService.deleteClassroomAccount(classroomAccountId);

--- a/src/main/java/soma/edupilms/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupilms/classroom/account/service/ClassroomAccountService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import soma.edupilms.classroom.account.models.ClassroomAccountResponse;
 import soma.edupilms.classroom.account.models.GuestsResponse;
 import soma.edupilms.classroom.account.models.RegisterGuestRequest;
+import soma.edupilms.progress.service.models.ActionStatus;
 import soma.edupilms.web.client.DbServerApiClient;
 
 @Service
@@ -21,6 +22,16 @@ public class ClassroomAccountService {
     public GuestsResponse getAllClassroomAccounts(Long classroomId) {
         List<ClassroomAccountResponse> guests = dbServerApiClient.getClassroomAccountBy(classroomId);
         return new GuestsResponse(guests);
+    }
+
+    public GuestsResponse getClassroomAccountsWithoutDefaultAction(Long classroomId) {
+        List<ClassroomAccountResponse> guests = dbServerApiClient.getClassroomAccountBy(classroomId);
+
+        List<ClassroomAccountResponse> filteredGuests = guests.stream()
+            .filter(guest -> !guest.getStatus().equals(ActionStatus.DEFAULT))
+            .toList();
+
+        return new GuestsResponse(filteredGuests);
     }
 
     public void deleteClassroomAccount(Long classroomAccountId) {

--- a/src/main/java/soma/edupilms/progress/ProgressController.java
+++ b/src/main/java/soma/edupilms/progress/ProgressController.java
@@ -1,11 +1,13 @@
 package soma.edupilms.progress;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -21,6 +23,18 @@ public class ProgressController {
 
     private final SseService sseService;
 
+    @GetMapping("/v1/guest/classroom/account")
+    public ResponseEntity<SuccessResponse> guestClassroomAccount(
+        @RequestParam Long classroomId,
+        @RequestHeader("X-Account-Id") Long accountId
+    ) {
+        ActionStatus actionStatus = sseService.getAction(classroomId, accountId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(SuccessResponse.withDetailAndResult("Success find guest action", actionStatus));
+    }
+
     @GetMapping(value = "/v1/progress/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> connect(@RequestParam String classroomId) {
         System.out.println("classroomId = " + classroomId);
@@ -34,7 +48,7 @@ public class ProgressController {
         System.out.println("actionRequest.getActionType() = " + actionChangeRequest.getAction());
         ActionStatus actionStatus = sseService.sendAction(actionChangeRequest);
 
-        return ResponseEntity.ok(SuccessResponse.withDetailAndResult("액션이 변경되었습니다.", actionStatus));
+        return ResponseEntity.ok(SuccessResponse.withDetailAndResult("Success change guest action", actionStatus));
 
     }
 

--- a/src/main/java/soma/edupilms/progress/models/ActionChangeRequest.java
+++ b/src/main/java/soma/edupilms/progress/models/ActionChangeRequest.java
@@ -11,4 +11,10 @@ public class ActionChangeRequest {
     private Long classroomId;
     private Long accountId;
     private ActionStatus action;
+
+    public ActionChangeRequest(Long classroomId, Long accountId, ActionStatus action) {
+        this.classroomId = classroomId;
+        this.accountId = accountId;
+        this.action = action;
+    }
 }

--- a/src/main/java/soma/edupilms/progress/service/RedisService.java
+++ b/src/main/java/soma/edupilms/progress/service/RedisService.java
@@ -2,7 +2,6 @@ package soma.edupilms.progress.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -62,9 +61,6 @@ public class RedisService {
             try {
                 String channel = new String(message.getChannel())
                     .substring(CHANNEL_PREFIX.length());
-
-                System.out.println("channel = " + channel);
-                System.out.println("message.getBody() = " + Arrays.toString(message.getBody()));
 
                 ActionChangeRequest actionChangeRequest = objectMapper.readValue(
                     message.getBody(),

--- a/src/main/java/soma/edupilms/progress/service/SseService.java
+++ b/src/main/java/soma/edupilms/progress/service/SseService.java
@@ -1,5 +1,6 @@
 package soma.edupilms.progress.service;
 
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,13 +21,13 @@ public class SseService {
 
     private static final Long TIME_OUT = 60 * 1000L; // 1분
 
-    public SseEmitter createOrGetConnection(String classroomId) {
+    public SseEmitter createOrGetConnection(String classroomId, Long accountId) {
 
         redisService.subscribe(classroomId);
 
         // sseEmitter 가져오기 없으면 만들어서 반환
         return sseEmitters.findSseEmitter(classroomId)
-            .orElseGet(() -> createNewSseEmitter(classroomId));
+            .orElseGet(() -> createNewSseEmitter(classroomId, accountId));
     }
 
     public ActionStatus sendAction(ActionChangeRequest actionChangeRequest) {
@@ -47,7 +48,7 @@ public class SseService {
         return actionStatus;
     }
 
-    private SseEmitter createNewSseEmitter(String classroomId) {
+    private SseEmitter createNewSseEmitter(String classroomId, Long accountId) {
         final SseEmitter sseEmitter = new SseEmitter(TIME_OUT);
 
         sseEmitters.create(classroomId, sseEmitter);
@@ -60,6 +61,12 @@ public class SseService {
             redisService.removeSubscribe(classroomId);
         });
 
+        try {
+            sseEmitter.send(SseEmitter.event().name("action")
+                .data(new ActionChangeRequest(Long.parseLong(classroomId), accountId, ActionStatus.DEFAULT)));
+        } catch (IOException e) {
+            sseEmitters.delete(classroomId);
+        }
         return sseEmitter;
     }
 }

--- a/src/main/java/soma/edupilms/progress/service/SseService.java
+++ b/src/main/java/soma/edupilms/progress/service/SseService.java
@@ -35,6 +35,18 @@ public class SseService {
         return actionStatus;
     }
 
+    public ActionStatus getAction(Long classroomId, Long accountId) {
+        ActionStatus actionStatus = dbServerApiClient.getActionStatus(classroomId, accountId);
+        if (actionStatus == ActionStatus.DEFAULT) {
+            ActionChangeRequest actionChangeRequest = new ActionChangeRequest(classroomId, accountId, ActionStatus.ING);
+            actionStatus = dbServerApiClient.updateAction(actionChangeRequest);
+
+            sendAction(actionChangeRequest);
+        }
+
+        return actionStatus;
+    }
+
     private SseEmitter createNewSseEmitter(String classroomId) {
         final SseEmitter sseEmitter = new SseEmitter(TIME_OUT);
 

--- a/src/main/java/soma/edupilms/web/GlobalExceptionHandler.java
+++ b/src/main/java/soma/edupilms/web/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package soma.edupilms.web;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -67,6 +68,7 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(new ErrorResponse("LM-400999", "예상하지 못한 에러가 발생했습니다."));
     }
 

--- a/src/main/java/soma/edupilms/web/client/DbServerApiClient.java
+++ b/src/main/java/soma/edupilms/web/client/DbServerApiClient.java
@@ -51,4 +51,7 @@ public interface DbServerApiClient {
 
     @GetExchange("/v1/classroom/info")
     ClassroomInfoResponse getClassroomInfo(@RequestParam Long classroomId);
+
+    @GetExchange("/v1/classroom/account/action")
+    ActionStatus getActionStatus(@RequestParam Long classroomId, @RequestParam Long accountId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #31

## 📝 작업 내용

- 시각화 페이지에 접속시 교육자에게 정보 전달
- 진척도 페이지와 설정 페이지 학생 조회 api 분리
- log 처리

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
