### PR TITLE
[#36]fix: develop이 아닌 main에 푸쉬되면 aws 배포하도록 수정

### DIFF
--- a/.github/workflows/cicd-dev.yml
+++ b/.github/workflows/cicd-dev.yml
@@ -2,7 +2,7 @@ name: Deploy to Amazon ECS
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 env:
   AWS_REGION: ap-northeast-2


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #36 

## 📝 작업 내용

- develop이 아닌 main에 푸쉬되면 aws 배포하도록 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
