### PR TITLE
[#38]feat: 클래스룸 계정 역할 확인 api 추가

### DIFF
--- a/src/main/java/soma/edupilms/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupilms/classroom/account/ClassroomAccountController.java
@@ -7,8 +7,10 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import soma.edupilms.classroom.account.models.CheckClassroomAccountRole;
 import soma.edupilms.classroom.account.models.ClassroomAccountResponse;
 import soma.edupilms.classroom.account.models.GuestsResponse;
 import soma.edupilms.classroom.account.models.RegisterGuestRequest;
@@ -23,17 +25,17 @@ public class ClassroomAccountController {
 
     @PostMapping("/v1/classroom/account")
     public ResponseEntity<SuccessResponse> registerClassroomAccount(
-        @RequestBody RegisterGuestRequest registerGuestRequest
+            @RequestBody RegisterGuestRequest registerGuestRequest
     ) {
         ClassroomAccountResponse classroomAccountResponse = classroomAccountService.registerClassroomAccount(
-            registerGuestRequest);
+                registerGuestRequest);
 
         return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(SuccessResponse.withDetailAndResult(
-                "success create classroom account",
-                classroomAccountResponse
-            ));
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.withDetailAndResult(
+                        "success create classroom account",
+                        classroomAccountResponse
+                ));
 
     }
 
@@ -42,24 +44,24 @@ public class ClassroomAccountController {
         GuestsResponse classroomAccountResponses = classroomAccountService.getAllClassroomAccounts(classroomId);
 
         return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(SuccessResponse.withDetailAndResult(
-                "success retrieved classroom account by classroomId",
-                classroomAccountResponses
-            ));
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.withDetailAndResult(
+                        "success retrieved classroom account by classroomId",
+                        classroomAccountResponses
+                ));
     }
 
     @GetMapping("/v1/classroom/account/progress")
     public ResponseEntity<SuccessResponse> getClassroomAccountWithoutDefaultAction(@RequestParam Long classroomId) {
         GuestsResponse classroomAccountResponses =
-            classroomAccountService.getClassroomAccountsWithoutDefaultAction(classroomId);
+                classroomAccountService.getClassroomAccountsWithoutDefaultAction(classroomId);
 
         return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(SuccessResponse.withDetailAndResult(
-                "success retrieved classroom account without default action by classroomId",
-                classroomAccountResponses
-            ));
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.withDetailAndResult(
+                        "success retrieved classroom account without default action by classroomId",
+                        classroomAccountResponses
+                ));
     }
 
     @DeleteMapping("/v1/classroom/account")
@@ -67,9 +69,26 @@ public class ClassroomAccountController {
         classroomAccountService.deleteClassroomAccount(classroomAccountId);
 
         return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(SuccessResponse.withDetail(
-                "success delete classroom account"
-            ));
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.withDetail(
+                        "success delete classroom account"
+                ));
+    }
+
+    @GetMapping("/v1/classroom/account/role")
+    public ResponseEntity<SuccessResponse> checkClassroomAccountRole(
+            @RequestHeader("X-Account-Id") Long accountId,
+            @RequestParam Long classroomId
+    ) {
+        CheckClassroomAccountRole checkClassroomAccountRole = classroomAccountService.checkClassroomAccountRole(
+                accountId, classroomId
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.withDetailAndResult(
+                        "success check classroom account role",
+                        checkClassroomAccountRole
+                ));
     }
 }

--- a/src/main/java/soma/edupilms/classroom/account/models/CheckClassroomAccountRole.java
+++ b/src/main/java/soma/edupilms/classroom/account/models/CheckClassroomAccountRole.java
@@ -1,0 +1,16 @@
+package soma.edupilms.classroom.account.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CheckClassroomAccountRole {
+
+    @JsonProperty(value = "isAccess")
+    private final boolean isAccess;
+    @JsonProperty(value = "isHost")
+    private final boolean isHost;
+
+    public CheckClassroomAccountRole(boolean isAccess, boolean isHost) {
+        this.isAccess = isAccess;
+        this.isHost = isHost;
+    }
+}

--- a/src/main/java/soma/edupilms/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupilms/classroom/account/service/ClassroomAccountService.java
@@ -3,6 +3,7 @@ package soma.edupilms.classroom.account.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import soma.edupilms.classroom.account.models.CheckClassroomAccountRole;
 import soma.edupilms.classroom.account.models.ClassroomAccountResponse;
 import soma.edupilms.classroom.account.models.GuestsResponse;
 import soma.edupilms.classroom.account.models.RegisterGuestRequest;
@@ -28,8 +29,8 @@ public class ClassroomAccountService {
         List<ClassroomAccountResponse> guests = metaServerApiClient.getClassroomAccountBy(classroomId);
 
         List<ClassroomAccountResponse> filteredGuests = guests.stream()
-            .filter(guest -> !guest.getStatus().equals(ActionStatus.DEFAULT))
-            .toList();
+                .filter(guest -> !guest.getStatus().equals(ActionStatus.DEFAULT))
+                .toList();
 
         return new GuestsResponse(filteredGuests);
     }
@@ -38,4 +39,7 @@ public class ClassroomAccountService {
         metaServerApiClient.deleteClassroomAccount(classroomAccountId);
     }
 
+    public CheckClassroomAccountRole checkClassroomAccountRole(Long accountId, Long classroomId) {
+        return metaServerApiClient.checkClassroomAccountRole(accountId, classroomId);
+    }
 }

--- a/src/main/java/soma/edupilms/web/client/MetaServerApiClient.java
+++ b/src/main/java/soma/edupilms/web/client/MetaServerApiClient.java
@@ -9,6 +9,7 @@ import org.springframework.web.service.annotation.DeleteExchange;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.PatchExchange;
 import org.springframework.web.service.annotation.PostExchange;
+import soma.edupilms.classroom.account.models.CheckClassroomAccountRole;
 import soma.edupilms.classroom.account.models.ClassroomAccountResponse;
 import soma.edupilms.classroom.account.models.RegisterGuestRequest;
 import soma.edupilms.classroom.models.ActionInitRequest;
@@ -54,4 +55,7 @@ public interface MetaServerApiClient {
 
     @GetExchange("/v1/classroom/account/action")
     ActionStatus getActionStatus(@RequestParam Long classroomId, @RequestParam Long accountId);
+
+    @GetExchange("/v1/classroom/account/role")
+    CheckClassroomAccountRole checkClassroomAccountRole(@RequestParam Long accountId, @RequestParam Long classroomId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #38 

## 📝 작업 내용

- 클래스룸 계정 역할 확인 api 추가

### 스크린샷 (선택)
![스크린샷 2024-11-06 16 50 01](https://github.com/user-attachments/assets/f03b2e32-ec8c-4c5e-8b9c-627d66ea19bb)

isAccess -> 접속 가능 여부
isHost -> 호스트인지 아닌지


## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
