### PR TITLE
[#48]feat: 학생 요청으로 코드를 저장하고 진척도 페이지에서 조회하는 기능 구현

### DIFF
--- a/src/main/java/soma/edupilms/classroom/account/ClassroomAccountController.java
+++ b/src/main/java/soma/edupilms/classroom/account/ClassroomAccountController.java
@@ -91,4 +91,19 @@ public class ClassroomAccountController {
                         checkClassroomAccountRole
                 ));
     }
+
+    @GetMapping("/v1/classroom/account/code")
+    public ResponseEntity<SuccessResponse> code(
+            @RequestParam Long classroomAccountId
+    ) {
+        String code = classroomAccountService.getClassroomAccountCode(classroomAccountId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.withDetailAndResult(
+                        "success find classroom account code",
+                        code
+                ));
+    }
+
 }

--- a/src/main/java/soma/edupilms/classroom/account/service/ClassroomAccountService.java
+++ b/src/main/java/soma/edupilms/classroom/account/service/ClassroomAccountService.java
@@ -108,4 +108,9 @@ public class ClassroomAccountService {
             throw new ClassroomException(ErrorEnum.TASK_FAIL);
         }
     }
+
+    public String getClassroomAccountCode(Long classroomAccountId) {
+        return metaServerApiClient.getCode(classroomAccountId);
+    }
+    
 }

--- a/src/main/java/soma/edupilms/progress/models/ActionChangeRequest.java
+++ b/src/main/java/soma/edupilms/progress/models/ActionChangeRequest.java
@@ -10,11 +10,17 @@ public class ActionChangeRequest {
 
     private Long classroomId;
     private Long accountId;
+    private String code;
     private ActionStatus action;
 
-    public ActionChangeRequest(Long classroomId, Long accountId, ActionStatus action) {
+    public ActionChangeRequest(Long classroomId, Long accountId, String code, ActionStatus action) {
         this.classroomId = classroomId;
         this.accountId = accountId;
+        this.code = code;
         this.action = action;
+    }
+
+    public void changeEmptyCode() {
+        this.code = "";
     }
 }

--- a/src/main/java/soma/edupilms/web/client/MetaServerApiClient.java
+++ b/src/main/java/soma/edupilms/web/client/MetaServerApiClient.java
@@ -47,6 +47,9 @@ public interface MetaServerApiClient {
     @DeleteExchange("/v1/classroom/account")
     void deleteClassroomAccount(@RequestParam Long classroomAccountId);
 
+    @PostExchange("/v1/classroom/account/code")
+    Long saveCode(@RequestBody ActionChangeRequest actionChangeRequest);
+
     @PostExchange("/v1/classroom/account/action")
     ActionStatus updateAction(@RequestBody ActionChangeRequest actionChangeRequest);
 

--- a/src/main/java/soma/edupilms/web/client/MetaServerApiClient.java
+++ b/src/main/java/soma/edupilms/web/client/MetaServerApiClient.java
@@ -50,6 +50,9 @@ public interface MetaServerApiClient {
     @PostExchange("/v1/classroom/account/code")
     Long saveCode(@RequestBody ActionChangeRequest actionChangeRequest);
 
+    @GetExchange("/v1/classroom/account/code")
+    String getCode(@RequestParam Long classroomAccountId);
+
     @PostExchange("/v1/classroom/account/action")
     ActionStatus updateAction(@RequestBody ActionChangeRequest actionChangeRequest);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #47 
- close #48

## 📝 작업 내용

- 진척도 페이지에서 도움이나 완료한 학생을 선택하면 코드를 보여주는 기능 추가
- 학생이 도움이나 완료 요청을 한 경우에 코드 저장

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
